### PR TITLE
adds relationship between users and courses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'webmock'
   gem 'dotenv-rails'
+  gem 'shoulda-matchers', '~> 4.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,8 @@ GEM
     rspec-support (3.9.3)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
+    shoulda-matchers (4.3.0)
+      activesupport (>= 4.2.0)
     simple_command (0.1.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
@@ -229,6 +231,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 6.0.2, >= 6.0.2.2)
   rspec-rails
+  shoulda-matchers (~> 4.0)
   simple_command
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,4 +2,6 @@ class Course < ApplicationRecord
   validates :courseCode, presence: true
   validates :description, presence: true
   validates :name, presence: true
+
+  has_many :users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   validates :password, presence: true
   validates :user_type, presence: true
 
+  belongs_to :course, optional: true
+
   def self.authenticate(email, password)
     user = find_by_email(email)
     if user && user.password == password

--- a/db/migrate/20200618091705_add_course_to_user.rb
+++ b/db/migrate/20200618091705_add_course_to_user.rb
@@ -1,0 +1,5 @@
+class AddCourseToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :users, :course, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_135857) do
+ActiveRecord::Schema.define(version: 2020_06_18_091705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,9 @@ ActiveRecord::Schema.define(version: 2020_05_26_135857) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "image_url"
+    t.bigint "course_id"
+    t.index ["course_id"], name: "index_users_on_course_id"
   end
 
+  add_foreign_key "users", "courses"
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Course, type: :model do
+
+  it { is_expected.to have_many(:users) }
+ 
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe User, type: :model do
   before do
     user= User.create(first_name: 'Julius', last_name: 'Ngwu', email:'julius@gmail.com',password:'julius@1', user_type:'mentee')
   end
+
+  it { should belong_to(:course).optional(true) }
+
   it 'is valid when all attributes are provided' do
     expect(user).to be_valid
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,6 +73,13 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
+
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 


### PR DESCRIPTION
#### What does this PR do?
 - [x] generates migration with courses reference
 - [x] adds a has_many users relationship to ourses
 - [x] adds a belongs to course relationship to users
 - [x] adds shoulda-matchers gem to test relationships

#### How can this PR be tested
* clone the repo 
`git clone https://github.com/oneworldcoders/hm_04_26_one_world_mentors_backend.git`
* change to the. repo directory
`cd hm_04_26_one_world_mentors_backend`
* checkout this branch 
`git checkout ft_mentee_course_relationship`
* install necessary gems
`bundle install`
* run migrations
`rake db:migrate`
* start the server
`rails s`
* open postman hit the users' endpoint (authentication required)
` http://localhost:3000/user/1`

#### Expected results
A course reference is added to the user query result
##### Before
<img width="822" alt="Screen Shot 2020-06-18 at 12 11 16" src="https://user-images.githubusercontent.com/26769886/85008276-0b6d2a80-b15d-11ea-9163-44554ad77ee3.png">

##### After
<img width="799" alt="Screen Shot 2020-06-18 at 12 06 21" src="https://user-images.githubusercontent.com/26769886/85007707-2a1ef180-b15c-11ea-89e8-c978df3877fa.png">
